### PR TITLE
Version 1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.2.5
+
+- [Android] Update SDK to 5.8.4 (https://github.com/mixpanel/mixpanel-android/releases/tag/v5.8.4)
+- [Android] Add option to disable automatic flushing when the app goes into the background. Add the following to you <application> tag on your AndroidManifest.xml if you don't want the SDK to automatically flush its queues when the app goes into the background: (https://github.com/mixpanel/mixpanel-android/releases/tag/v5.8.3)
+- [iOS] Update SDK to 3.6.2 (https://github.com/mixpanel/mixpanel-iphone/releases/tag/v3.6.2)
+- [iOS] Remove IFA/IDFA - Removing using IFA as distinct id. Beginning with this version, Mixpanel no longer uses the IFA(ID for Advertisers) but uses a randomly generated UUID as the default distinct ID instead. After you call reset, Mixpanel generates a new distinct_id by default. This ensures that multiple users on the same device are not assigned the same alias. If you want to use IFV(identifierForVendor) as the distinct_id, you can set MIXPANEL_UNIQUE_DISTINCT_ID=1 in build settings Preprocessor Macros on the Mixpanel framework target. After you call reset, the IFV will not change. However, when a user removes and then re-installs the app, the IFV will change with each installation. More: (https://github.com/mixpanel/mixpanel-iphone/releases/tag/v3.6.2)
+- [iOS] All fixes from SDK 3.6.1: (https://github.com/mixpanel/mixpanel-iphone/releases/tag/v3.6.1)
+- Allow to configure mixpanel server urls, e.g. https://api-eu.mixpanel.com More in README.md
+- [iOS] Add access to the setAppSessionPropertiesIOS which was not exposed 
+
 # 1.2.4
 
 - [Android] Update SDK to 5.8.2 (https://github.com/mixpanel/mixpanel-android/releases/tag/v5.8.2)

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ This behaviour can be disabled by default, and explicitally triggered at a later
 For iOS, in your app delegate, add the following line:
 
 ```
-// In application:didFinishLaunchingWithOptions:
+// In (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions:
 Mixpanel *mixpanel = [Mixpanel sharedInstanceWithToken:YOUR_MIXPANEL_TOKEN];
 // Turn this off so the message doesn't pop up automatically.
 mixpanel.showNotificationOnActive = NO;

--- a/README.md
+++ b/README.md
@@ -330,5 +330,27 @@ For Android, add the following to your app mainifest in the `<application>` tag:
 
 More info: https://help.mixpanel.com/hc/en-us/articles/115004494803-Disable-Geolocation-Collection
 
+## Configure mixpanel urls
+
+Add server url in `.plist` files in iOS project.
+
+```
+<key>com.mixpanel.config.serverURL</key>
+<string>https://api-eu.mixpanel.com</string>
+```
+
+Add endpoints to `manifest` in your Android project.
+
+```
+<application ...>
+    <meta-data android:name="com.mixpanel.android.MPConfig.EventsEndpoint"
+        android:value="https://api-eu.mixpanel.com/track" />
+    <meta-data android:name="com.mixpanel.android.MPConfig.PeopleEndpoint"
+        android:value="https://api-eu.mixpanel.com/engage" />
+    <meta-data android:name="com.mixpanel.android.MPConfig.GroupsEndpoint"
+        android:value="https://api-eu.mixpanel.com/groups" />
+</application>
+```
+
 ## Notes ##
 For more info please have a look at the [official Mixpanel reference](https://mixpanel.com/help/reference/ios) for iOS

--- a/README.md
+++ b/README.md
@@ -271,6 +271,13 @@ Mixpanel.reset();
 // get the last distinct id set with identify or, if identify hasn't been
 // called, the default mixpanel id for this device.
 Mixpanel.getDistinctId(function(id){})
+
+// iOS
+// Allows control of the min/max sessions 
+Mixpanel.setAppSessionPropertiesIOS({
+  minimumSessionDuration: 60,
+  maximumSessionDuration: 10,
+});
 ```
 
 ## Displaying in-app messages ##

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -47,6 +47,11 @@ RCT_EXPORT_METHOD(sharedInstanceWithToken:(NSString *)apiToken
                                          automaticPushTracking:automaticPushTracking
                                        optOutTrackingByDefault:optOutTrackingByDefault];
 
+        NSString *serverURL = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"com.mixpanel.config.serverURL"];
+        if (serverURL != nil) {
+            instance.serverURL = serverURL;
+        }
+
         // copy instances and add the new instance.  then reassign instances
         NSMutableDictionary *newInstances = [NSMutableDictionary dictionaryWithDictionary:instances];
         [newInstances setObject:instance forKey:apiToken];

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,5 +17,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api "com.mixpanel.android:mixpanel-android:5.8.2"
+    api "com.mixpanel.android:mixpanel-android:5.8.4"
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,7 @@ declare module 'react-native-mixpanel' {
     getPushRegistrationId(): Promise<string>
 
     // iOS only
+    setAppSessionPropertiesIOS(properties: Object): Promise<void>
     removePushDeviceToken(pushDeviceToken: string): Promise<void>
     removeAllPushDeviceTokens(): Promise<void>
     addPushDeviceToken(token: string): Promise<void>
@@ -75,6 +76,7 @@ declare module 'react-native-mixpanel' {
     getPushRegistrationId(callback: (token?: string) => void): void;
 
     // iOS only
+    setAppSessionPropertiesIOS(properties: Object): Promise<void>;
     addPushDeviceToken(token: string): void;
     removePushDeviceToken(pushDeviceToken: string): void;
     removeAllPushDeviceTokens(): void;

--- a/index.js
+++ b/index.js
@@ -204,6 +204,14 @@ export class MixpanelInstance {
     return RNMixpanel.addPushDeviceToken(token, this.apiToken)
   }
 
+  // iOS only
+  setAppSessionPropertiesIOS(properties: Object): Promise<void> {
+    if (!this.initialized) throw new Error(uninitializedError('setAppSessionPropertiesIOS'))
+
+    if (!RNMixpanel.setAppSessionPropertiesIOS) throw new Error('No native implementation for setAppSessionPropertiesIOS.  This is iOS only.')
+    return RNMixpanel.setAppSessionPropertiesIOS(properties)
+  }
+
   // android only
   setPushRegistrationId(token: string): Promise<void> {
     if (!this.initialized) throw new Error(uninitializedError('setPushRegistrationId'))
@@ -444,6 +452,13 @@ export default {
     if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
 
     defaultInstance.addPushDeviceToken(token)
+  },
+
+  // iOS only
+  setAppSessionPropertiesIOS(properties: Object) {
+    if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
+
+    defaultInstance.setAppSessionPropertiesIOS(properties)
   },
 
   // android only

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mixpanel",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "A React Native wrapper for Mixpanel tracking",
   "main": "index.js",
   "repository": {

--- a/react-native-mixpanel.podspec
+++ b/react-native-mixpanel.podspec
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.homepage     = package['homepage']
   s.source       = { :git => "https://github.com/davodesign84/react-native-mixpanel.git" }
   s.source_files = 'RNMixpanel/*'
-  s.platform     = :ios, "8.0"
+  s.platform     = :ios, "10.0"
   s.tvos.deployment_target = '10.0'
-  s.dependency 'Mixpanel', '3.6.0'
+  s.dependency 'Mixpanel', '3.6.2'
   s.dependency 'React'
 end


### PR DESCRIPTION
- [Android] Update SDK to 5.8.4 (https://github.com/mixpanel/mixpanel-android/releases/tag/v5.8.4)
- [Android] Add option to disable automatic flushing when the app goes into the background. Add the following to you <application> tag on your AndroidManifest.xml if you don't want the SDK to automatically flush its queues when the app goes into the background: (https://github.com/mixpanel/mixpanel-android/releases/tag/v5.8.3)
- [iOS] Update SDK to 3.6.2 (https://github.com/mixpanel/mixpanel-iphone/releases/tag/v3.6.2)
- [iOS] Remove IFA/IDFA - Removing using IFA as distinct id. Beginning with this version, Mixpanel no longer uses the IFA(ID for Advertisers) but uses a randomly generated UUID as the default distinct ID instead. After you call reset, Mixpanel generates a new distinct_id by default. This ensures that multiple users on the same device are not assigned the same alias. If you want to use IFV(identifierForVendor) as the distinct_id, you can set MIXPANEL_UNIQUE_DISTINCT_ID=1 in build settings Preprocessor Macros on the Mixpanel framework target. After you call reset, the IFV will not change. However, when a user removes and then re-installs the app, the IFV will change with each installation. More: (https://github.com/mixpanel/mixpanel-iphone/releases/tag/v3.6.2)
- [iOS] All fixes from SDK 3.6.1: (https://github.com/mixpanel/mixpanel-iphone/releases/tag/v3.6.1)
- Allow to configure mixpanel server urls, e.g. https://api-eu.mixpanel.com More in README.md
- [iOS] Add access to the setAppSessionPropertiesIOS which was not exposed 