### PR TITLE
1.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 1.2.8
 
 - Unify how `reset()` method works on iOS and Android. This change should close an issue: https://github.com/davodesign84/react-native-mixpanel/issues/258 `reset()` method will contain new params: `flushOnReset` and `autoGenerateNewUniqueId`. Reset method is backward compatible. More in README.md
-- Fix `sharedInstanceWithToken` method
+- Fix `sharedInstanceWithToken` method definition
 
 
 # 1.2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.8
+
+- Unify how `reset()` method works on iOS and Android. This change should close an issue: https://github.com/davodesign84/react-native-mixpanel/issues/258 `reset()` method will contain new params: `flushOnReset` and `autoGenerateNewUniqueId`. Reset method is backward compatible. More in README.md
+- Fix `sharedInstanceWithToken` method
+
+
 # 1.2.7
 
 - [Android] Update SDK to 5.8.5 (https://github.com/mixpanel/mixpanel-android/releases/tag/v5.8.5)

--- a/README.md
+++ b/README.md
@@ -265,8 +265,12 @@ Mixpanel.removePushDeviceToken(pushDeviceToken: string);
 // Unregister the given device to receive push notifications.
 Mixpanel.removeAllPushDeviceTokens();
 
-// Mixpanel reset method (warning: it will also generate a new unique id and call the identify method with it. Thus, the user will not be anonymous in Mixpanel.)
+// Mixpanel reset method (warning: by default it will also generate a new unique id and call the identify method with it. Thus, the user will not be anonymous in Mixpanel.)
+//  @param flushOnReset - will flush data on reset (default value: true)
+//  @param autoGenerateNewUniqueId - determines if new unique id should be generated automaticaly or not (default value: true)
 Mixpanel.reset();
+Mixpanel.reset(false);
+Mixpanel.reset(true, false);
 
 // get the last distinct id set with identify or, if identify hasn't been
 // called, the default mixpanel id for this device.

--- a/RNMixpanel/RNMixpanel.m
+++ b/RNMixpanel/RNMixpanel.m
@@ -329,11 +329,21 @@ RCT_EXPORT_METHOD(append:(NSString *)name
 
 // reset
 RCT_EXPORT_METHOD(reset:(NSString *)apiToken
+                  flushOnReset:(BOOL)flushOnReset
+                  autoGenerateNewUniqueId:(BOOL)autoGenerateNewUniqueId
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
+    if (flushOnReset) {
+        [[self getInstance:apiToken] flush];
+    }
+    
     [[self getInstance:apiToken] reset];
-    NSString *uuid = [[NSUUID UUID] UUIDString];
-    [[self getInstance:apiToken] identify:uuid];
+    
+    if (autoGenerateNewUniqueId) {
+        NSString *uuid = [[NSUUID UUID] UUIDString];
+        [[self getInstance:apiToken] identify:uuid];
+    }
+    
     resolve(nil);
 }
 

--- a/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
+++ b/android/src/main/java/com/kevinejohn/RNMixpanel/RNMixpanelModule.java
@@ -18,6 +18,7 @@ import org.json.JSONObject;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Mixpanel React Native module.
@@ -415,11 +416,18 @@ public class RNMixpanelModule extends ReactContextBaseJavaModule implements Life
     }
 
     @ReactMethod
-    public void reset(final String apiToken, Promise promise) {
+    public void reset(final String apiToken, final Boolean flushOnReset, final Boolean autoGenerateNewUniqueId, Promise promise) {
         final MixpanelAPI instance = getInstance(apiToken);
         synchronized(instance) {
+            if (flushOnReset) {
+                instance.flush();
+            }
             instance.reset();
-            instance.flush();
+            if (autoGenerateNewUniqueId) {
+                String uniqueId = UUID.randomUUID().toString();
+                instance.identify(uniqueId);
+                instance.getPeople().identify(uniqueId);
+            }
         }
         promise.resolve(null);
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ declare module 'react-native-mixpanel' {
     union(name: string, properties: any[]): Promise<void>
     append(name: string, properties: any[]): Promise<void>
     clearSuperProperties(): Promise<void>
-    reset(): Promise<void>
+    reset(flushOnReset?: boolean, autoGenerateNewUniqueId?: boolean): Promise<void>
     showInAppMessageIfAvailable(): Promise<void>
     optInTracking(): Promise<void>
     optOutTracking(): Promise<void>
@@ -63,7 +63,7 @@ declare module 'react-native-mixpanel' {
     union(name: string, properties: any[]): void;
     append(name: string, properties: any[]): void;
     clearSuperProperties(): void;
-    reset(): void;
+    reset(flushOnReset?: boolean, autoGenerateNewUniqueId?: boolean): void;
     showInAppMessageIfAvailable(): void;
     optInTracking(): void;
     optOutTracking(): void;

--- a/index.js
+++ b/index.js
@@ -228,10 +228,10 @@ export class MixpanelInstance {
     return RNMixpanel.clearPushRegistrationId(token, this.apiToken)
   }
 
-  reset(): Promise<void> {
+  reset(flushOnReset?: boolean = true, autoGenerateNewUniqueId?: boolean = true): Promise<void> {
     if (!this.initialized) throw new Error(uninitializedError('reset'))
 
-    return RNMixpanel.reset(this.apiToken)
+    return RNMixpanel.reset(this.apiToken, flushOnReset, autoGenerateNewUniqueId)
   }
 
   showInAppMessageIfAvailable(): Promise<void> {
@@ -475,10 +475,10 @@ export default {
     defaultInstance.clearPushRegistrationId(token)
   },
 
-  reset() {
+  reset(flushOnReset?: boolean = true, autoGenerateNewUniqueId?: boolean = true) {
     if (!defaultInstance) throw new Error(NO_INSTANCE_ERROR)
 
-    defaultInstance.reset()
+    defaultInstance.reset(flushOnReset, autoGenerateNewUniqueId)
   },
 
   showInAppMessageIfAvailable() {

--- a/index.js
+++ b/index.js
@@ -278,7 +278,7 @@ mixpanel.track('my event')
 export default {
 
   sharedInstanceWithToken(apiToken: string, optOutTrackingDefault: ?boolean = false, trackCrashes: ?boolean = true, automaticPushTracking: ?boolean = true, launchOptions: ?Object = null): Promise<void> {
-    const instance = new MixpanelInstance(apiToken, optOutTrackingDefault)
+    const instance = new MixpanelInstance(apiToken, optOutTrackingDefault, trackCrashes, automaticPushTracking, launchOptions)
     if (!defaultInstance) defaultInstance = instance
     return instance.initialize()
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mixpanel",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "A React Native wrapper for Mixpanel tracking",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
- Unify how `reset()` method works on iOS and Android. This change should close an issue: https://github.com/davodesign84/react-native-mixpanel/issues/258 `reset()` method will contain new params: `flushOnReset` and `autoGenerateNewUniqueId`. Reset method is backward compatible. More in README.md
- Fix `sharedInstanceWithToken` method definition
